### PR TITLE
put ftdetect autocmd inside augroup

### DIFF
--- a/ftdetect/csv.vim
+++ b/ftdetect/csv.vim
@@ -1,2 +1,6 @@
 " Install Filetype detection for CSV files
-au BufRead,BufNewFile *.csv,*.dat	set filetype=csv
+augroup ftdetect_csv
+    au!
+    au BufRead,BufNewFile *.csv,*.dat set filetype=csv
+augroup END
+


### PR DESCRIPTION
Sometimes, in my environment the ftdetect script was called multiple times. put ftdetect autocmd inside augroup can avoid duplicated autocmds.
