### PR TITLE
Keep other mappings functional when W/E/K/J are not mapped.

### DIFF
--- a/ftplugin/csv.vim
+++ b/ftplugin/csv.vim
@@ -1766,8 +1766,7 @@ fu! <sid>MoveOver(outer) "{{{3
             let mode = 1
         endif
     endif
-    " Use the mapped key
-    exe ":sil! norm E"
+    call <sid>MoveCol(-1, line("."))
     let _s = @/
     if last
         exe "sil! norm! /" . b:col . "\<cr>v$h" . (mode ? "" : "\<Left>")
@@ -1779,10 +1778,18 @@ endfu
 
 fu! <sid>CSVMappings() "{{{3
     call <sid>Map('noremap', 'W', ':<C-U>call <SID>MoveCol(1, line("."))<CR>')
+    call <sid>Map('noremap', '<C-Right>', ':<C-U>call <SID>MoveCol(1, line("."))<CR>')
+    call <sid>Map('noremap', 'L', ':<C-U>call <SID>MoveCol(1, line("."))<CR>')
     call <sid>Map('noremap', 'E', ':<C-U>call <SID>MoveCol(-1, line("."))<CR>')
+    call <sid>Map('noremap', '<C-Left>', ':<C-U>call <SID>MoveCol(-1, line("."))<CR>')
+    call <sid>Map('noremap', 'H', ':<C-U>call <SID>MoveCol(-1, line("."))<CR>')
     call <sid>Map('noremap', 'K', ':<C-U>call <SID>MoveCol(0,
         \ line(".")-v:count1)<CR>')
+    call <sid>Map('noremap', '<Up>', ':<C-U>call <SID>MoveCol(0,
+        \ line(".")-v:count1)<CR>')
     call <sid>Map('noremap', 'J', ':<C-U>call <SID>MoveCol(0,
+        \ line(".")+v:count1)<CR>')
+    call <sid>Map('noremap', '<Down>', ':<C-U>call <SID>MoveCol(0,
         \ line(".")+v:count1)<CR>')
     call <sid>Map('nnoremap', '<CR>', ':<C-U>call <SID>PrepareFolding(1,
         \ 1)<CR>')
@@ -1806,12 +1813,6 @@ fu! <sid>CSVMappings() "{{{3
     call <sid>Map('nnoremap', '<LocalLeader><CR>', '<CR>')
     call <sid>Map('nnoremap', '<LocalLeader><Space>', '<Space>')
     call <sid>Map('nnoremap', '<LocalLeader><BS>', '<BS>')
-    call <sid>Map('map', '<C-Right>', 'W')
-    call <sid>Map('map', '<C-Left>', 'E')
-    call <sid>Map('map', 'H', 'E')
-    call <sid>Map('map', 'L', 'W')
-    call <sid>Map('map', '<Up>', 'K')
-    call <sid>Map('map', '<Down>', 'J')
 endfu
 
 fu! <sid>CommandDefinitions() "{{{3


### PR DESCRIPTION
Instead of using `:map` to `W` for the duplicate `<C-Right>` and `L` mappings, duplicate the actual call with :noremap so that they are kept functional when the `W` key is not mapped (`:let g:csv_nomap_w = 1`). I personally don't need three alternatives for the same movement and prefer to keep the built-in W motion.

Also, the `<SID>MoveOver()` function should not rely on the E key mapping.
