### PR TITLE
Fix text objects when :set keymodel+=stopsel.

### DIFF
--- a/ftplugin/csv.vim
+++ b/ftplugin/csv.vim
@@ -1805,9 +1805,9 @@ fu! <sid>MoveOver(outer) "{{{3
 "    endif
     let _s = @/
     if last
-        exe "sil! norm! v$h" . (outer_field ? "" : "\<Left>") . (&sel ==# 'exclusive' ? "\<Right>" : '')
+        exe "sil! norm! v$h" . (outer_field ? "" : "h") . (&sel ==# 'exclusive' ? "l" : '')
     else
-        exe "sil! norm! v/." . b:col . "\<cr>\<Left>" . (outer_field ? "" : "\<Left>") . (&sel ==# 'exclusive' ? "\<Right>" : '')
+        exe "sil! norm! v/." . b:col . "\<cr>h" . (outer_field ? "" : "h") . (&sel ==# 'exclusive' ? "l" : '')
     endif
     let _wsv.col = col('.')-1
     call winrestview(_wsv)


### PR DESCRIPTION
Thanks for fixing #25 and #26 so quickly. However, the text objects still acted funny with my personal Vim configuration. Turns out that's a side effect of my changed `'keymodel'` option.

With that setting (which is set by :behave mswin), movement of cursor keys stops the visual selection, but the text objects are based on that. Replace the use of `<Left>` / `<Right>` with the canonical `h` / `l`; those are not affected by this setting.
