### PR TITLE
Fix errors when undoing filetype with g:csv_highlight_column

### DIFF
--- a/ftplugin/csv.vim
+++ b/ftplugin/csv.vim
@@ -229,8 +229,8 @@ fu! <sid>DoAutoCommands() "{{{3
         HiColumn!
     endif
     " undo autocommand:
-    let b:undo_ftplugin .= '| exe "sil! au! CSV_HI CursorMoved <buffer> "'
-    let b:undo_ftplugin .= '| exe "sil! aug! CSV_HI" |exe "sil! HiColumn!"'
+    let b:undo_ftplugin .= '| exe "sil! au! CSV_HI'.bufnr('').' CursorMoved <buffer> "'
+    let b:undo_ftplugin .= '| exe "sil! aug! CSV_HI'.bufnr('').'" |exe "sil! HiColumn!"'
 
     if has("gui_running") && !exists("#CSV_Menu#FileType")
         augroup CSV_Menu

--- a/ftplugin/csv.vim
+++ b/ftplugin/csv.vim
@@ -230,7 +230,8 @@ fu! <sid>DoAutoCommands() "{{{3
     endif
     " undo autocommand:
     let b:undo_ftplugin .= '| exe "sil! au! CSV_HI'.bufnr('').' CursorMoved <buffer> "'
-    let b:undo_ftplugin .= '| exe "sil! aug! CSV_HI'.bufnr('').'" |exe "sil! HiColumn!"'
+    let b:undo_ftplugin .= '| exe "sil! aug! CSV_HI'.bufnr('').'"'
+    let b:undo_ftplugin = 'exe "sil! HiColumn!" |' . b:undo_ftplugin
 
     if has("gui_running") && !exists("#CSV_Menu#FileType")
         augroup CSV_Menu


### PR DESCRIPTION
Fixes the following error when moving the cursor after running `set ft=` with `g:csv_highlight_column` enabled:

> Error detected while processing CursorMoved Auto commands for "<buffer=1>":
> E492: Not an editor command: HiColumn

This PR also fixes the clearing of the current highlight column when undoing the current file type.