### PR TITLE
Fixed ill output of `ArrangeColumn`: Use strdisplaywidth instead of s/./x/g

### DIFF
--- a/ftplugin/csv.vim
+++ b/ftplugin/csv.vim
@@ -595,9 +595,7 @@ fu! <sid>ColWidth(colnr, ...) "{{{3
             for item in b:csv_list
                 call add(tlist, get(item, a:colnr-1, ''))
             endfor
-            " do not strip leading whitespace
-            call map(tlist, 'substitute(v:val, ".", "x", "g")')
-            call map(tlist, 'strlen(v:val)')
+            call map(tlist, 'strdisplaywidth(v:val)')
             return max(tlist)
         catch
             throw "ColWidth-error"


### PR DESCRIPTION
I'm a Japanese user of your useful CSV plugin.

When I'm editing .csv files which includes Japanese (multi-byte) characters,
the results of `:ArrangeColumn` were ill because of the mismatch of estimated string width within the column.

I replaced the logic of counting with the built-in function `strdisplaywidth(v:val)`.
Then `:ArrangeColumn` worked very well.

Additionally, the comment `" do not strip leading whitespace` can be fulfilled by this change.

Thank you.

Before:
<img width="413" alt="before" src="https://user-images.githubusercontent.com/11067619/40825348-447680c2-65b2-11e8-9b35-63975028ad87.png">

After:
<img width="409" alt="after" src="https://user-images.githubusercontent.com/11067619/40825354-47a3c1ec-65b2-11e8-987d-c5a8e5ce5401.png">
