### PR TITLE
Fix ArrangeColumn for vartabs

### DIFF
--- a/autoload/csv.vim
+++ b/autoload/csv.vim
@@ -760,6 +760,10 @@ fu! csv#CalculateColumnWidth(row, silent) "{{{3
     " does not work with fixed width columns
     " row for the row for which to calculate the width
     let b:col_width=[]
+    if has( 'vartabs' ) && b:delimiter == "\t"
+        let vts_save=&vts
+        set vts=
+    endif
     try
         if exists("b:csv_headerline")
           if line('.') < b:csv_headerline
@@ -778,6 +782,9 @@ fu! csv#CalculateColumnWidth(row, silent) "{{{3
     " delete buffer content in variable b:csv_list,
     " this was only necessary for calculating the max width
     unlet! b:csv_list s:columnize_count s:decimal_column
+    if has( 'vartabs' ) && b:delimiter == "\t"
+        let &vts=vts_save
+    endif
 endfu
 fu! csv#Columnize(field) "{{{3
     " Internal function, not called from external,


### PR DESCRIPTION
When using varibale tabstops, the first time a file is opened, the
column width are calculated correctly. Howver, all subsequent
calculations were wrong, leading to increasingly wide separation.

To repro:

* `vim -c 'set ts=2 noet' test.tsv`
* `A<Tab>BCD<Tab>E`
* `AAAA<Tab>B<Tab>E`
* `:wq`
* `vim -c 'set ts=2 noet' test.tsv`
* observe columns aligned, but too wide
* `GoAAAA----------<Tab>B<Tab>E`
* `:%CSVArrangeColumn`
* observe columns aligned, but too wide
* `GoAAAA----------==========<Tab>B<Tab>E`
* `:%CSVArrangeColumn`
* Observe that the BCD column is 10 chars too wide

With the fix, it's the right width in all 3 places, based on the tabstop
value of `2`

The calulation of column widths uses strdisplaywidth(), which itself is
dependent on the current value of the tabstops. To avoid this, we
temporarily disable variable tabstops while calculating the column
widths.