### PR TITLE
Analyze: allow topN as a second parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,15 @@ This tells you, that the the value '10' in column 3 occurs 50% of the time
 (exactly 20 times) and the other 2 values '2' and '5' occur only 10 times, so
 25% of the time.
 
+In addition, a second argument may be used to specify the number of top values.
+So 
+
+```vim
+:Analyze 3 10
+```
+
+outputs the the distribution of the top 10 values in column 3, respectively.
+
 ## Vertical Folding
 
 Sometimes, you want to hide away certain columns to better view only certain

--- a/autoload/csv.vim
+++ b/autoload/csv.vim
@@ -1954,8 +1954,12 @@ fu! csv#CheckHeaderLine() "{{{3
 endfu
 fu! csv#AnalyzeColumn(...) "{{{3
     let maxcolnr = csv#MaxColumns()
-    if len(a:000) == 1
+    let topn = 5
+    if len(a:000) > 0
         let colnr = a:1
+        if len(a:000) == 2
+            let topn = a:2
+        endif
     else
         let colnr = csv#WColumn()
     endif
@@ -1983,8 +1987,8 @@ fu! csv#AnalyzeColumn(...) "{{{3
     let max_items = reverse(sort(values(res), s:csv_numeric_sort ? 'n' : 'csv#CSVSortValues'))
     " What about the minimum 5 items?
     let count_items = keys(res)
-    if len(max_items) > 5
-        call remove(max_items, 5, -1)
+    if len(max_items) > topn
+        call remove(max_items, topn, -1)
         call map(max_items, 'printf(''\V%s\m'', escape(v:val, ''\\''))')
         call filter(res, 'v:val =~ ''^''.join(max_items, ''\|'').''$''')
     endif
@@ -2309,8 +2313,8 @@ fu! csv#CommandDefinitions() "{{{3
         \ '-bang -nargs=? -range=%')
     call csv#LocalCmd("Filters", ':call csv#OutputFilters(<bang>0)',
         \ '-nargs=0 -bang')
-    call csv#LocalCmd("Analyze", ':call csv#AnalyzeColumn(<args>)',
-        \ '-nargs=?')
+    call csv#LocalCmd("Analyze", ':call csv#AnalyzeColumn(<f-args>)',
+        \ '-nargs=*' )
     call csv#LocalCmd("VertFold", ':call csv#Vertfold(<bang>0,<q-args>)',
         \ '-bang -nargs=? -range=% -complete=custom,csv#SortComplete')
     call csv#LocalCmd("CSVFixed", ':call csv#InitCSVFixedWidth()', '')

--- a/doc/ft-csv.txt
+++ b/doc/ft-csv.txt
@@ -812,6 +812,13 @@ This tells you, that the the value '10' in column 3 occurs 50% of the time
 (exactly 20 times) and the other 2 values '2' and '5' occur only 10 times, so
 25% of the time.
 
+In addition, a second argument may be used to specify the number of top values.
+So 
+
+    :Analyze 3 10
+
+outputs the the distribution of the top 10 values in column 3, respectively.
+
                                                  *:CSVVertFold* *VertFold_CSV*
 3.21 Vertical Folding       					 *csv-vertfold*
 ---------------------


### PR DESCRIPTION
Calling :Analyze 3 10 will now output the top 10 items of column 3

This is just a small addition to the Analyze command to allow for more than the default 5 top items of a column.

Cheers,
Sven