### PR TITLE
Added option to bind B instead of E

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ works differently.
 
 It will make use of the [vartabs](https://vimhelp.org/options.txt.html#%27vartabstop%27) feature for tab delimited files.
 
+By default, some remapings are done, including `E` to go back to the previous column (comma) which is obviously not the best option :
+it'd be logical to use `B` to do so. Fortunately, you can set your favourite key to do this action just by setting a variable in your config.
+Follow the indications [there](#map-b-instead-of-e-to-jump-back-to-previous-column) (also in the builtin docs).
+
 ![Screenshot](http://www.256bit.org/~chrisbra/csv.gif)
 
 # Table of Contents
@@ -67,6 +71,7 @@ It will make use of the [vartabs](https://vimhelp.org/options.txt.html#%27vartab
   * [Move folded lines](#move-folded-lines)
   * [Using comments](#using-comments)
   * [Size and performance considerations](#size-and-performance-considerations)
+  * [Map `B` instead of `E` to jump back to previous column](#map-b-instead-of-e-to-jump-back-to-previous-column)
 - [Functions](#functions)
   * [CSVPat()](#csvpat)
   * [CSVField(x,y[, orig])](#csvfieldxy-orig)
@@ -1575,6 +1580,24 @@ will disable syntax highlighting and the filetype commands for very large csv
 files (by default larger than 100 MB).
 
 See also [Slow CSV plugin](#slow-csv-plugin)
+
+## Map `B` instead of `E` to jump back to previous column
+
+Mapping E to go back a cell has no logic ; this feature lets the user choose
+to map B instead with the `g:csv_bind_B` variable (boolean) defined anywhere
+in his vim configuration. If it is not set, falls back to mapping E to
+previous column. Added by @lapingenieur ([lapingenieur over github](https://github.com/lapingenieur),
+email: lapingenieur@gmail.com).
+
+Exemple : I want to remap `B` to go to the previous column (comma) instead of `E`.
+Just put this in your counfig file :
+
+```vim
+    let g:csv_bind_B = 1
+```
+
+If you don't want this feature, you can just leave this variable without
+defining it : the script will automatically map `E`.
 
 # Functions
 

--- a/autoload/csv.vim
+++ b/autoload/csv.vim
@@ -2196,7 +2196,15 @@ fu! csv#CSVMappings() "{{{3
         call csv#Map('nnoremap', 'W', ':<C-U>call csv#MoveCol(1, line("."))<CR>')
         call csv#Map('nnoremap', '<C-Right>', ':<C-U>call csv#MoveCol(1, line("."))<CR>')
         call csv#Map('nnoremap', 'L', ':<C-U>call csv#MoveCol(1, line("."))<CR>')
-        call csv#Map('nnoremap', 'E', ':<C-U>call csv#MoveCol(-1, line("."))<CR>')
+        try
+            if g:csv_bind_B == 1
+                call csv#Map('nnoremap', 'B', ':<C-U>call csv#MoveCol(-1, line("."))<CR>')
+            else
+                call csv#Map('nnoremap', 'E', ':<C-U>call csv#MoveCol(-1, line("."))<CR>')
+            endif
+        catch
+            call csv#Map('nnoremap', 'E', ':<C-U>call csv#MoveCol(-1, line("."))<CR>')
+        endtry
         call csv#Map('nnoremap', '<C-Left>', ':<C-U>call csv#MoveCol(-1, line("."))<CR>')
         call csv#Map('nnoremap', 'H', ':<C-U>call csv#MoveCol(-1, line("."), 1)<CR>')
         call csv#Map('nnoremap', 'K', ':<C-U>call csv#MoveCol(0, line(".")-v:count1)<CR>')

--- a/doc/ft-csv.txt
+++ b/doc/ft-csv.txt
@@ -58,6 +58,7 @@ NO WARRANTY, EXPRESS OR IMPLIED.  USE AT-YOUR-OWN-RISK.
     4.11 Move folded lines......................|csv-move-folds|
     4.12 Using Comments.........................|csv-comments|
     4.13 Size and performance considerations....|csv-size|
+    4.14 Map `B` instead of `E` to jump back to previous column...|csv-bind-B|
 5. Functions....................................|CSV-Functions|
     5.1 CSVPat()................................|CSVPat()|
     5.2 CSVField()..............................|CSVField()|
@@ -1454,6 +1455,24 @@ disable syntax highlighting and the filetype commands for very large csv files
 (by default larger than 100 MB).
 
 See also |csv-slow|
+                                                                    *g:csv_bind_B*
+                                                                    *csv-bind-B*
+4.14 Map `B` instead of `E` to jump back to previous column             *csv-bind*
+-------------------------------------------------------
+
+Mapping E to go back a cell has no logic ; this feature lets the user choose
+to map B instead with the `g:csv_bind_B` variable (boolean) defined anywhere
+in his vim configuration. If it is not set, falls back to mapping E to
+previous column. Added by @lapingenieur (https://github.com/lapingenieur ;
+email: lapingenieur@gmail.com).
+
+Exemple : I want to remap `B` to go to the previous column (comma) instead of `E`
+>
+    let g:csv_bind_B = 1
+<
+If you don't want this feature, you can just leave this variable without
+defining it : the script will automatically map `E`
+
 ==============================================================================
 5. Functions                                                    *CSV-Functions*
 


### PR DESCRIPTION
Mapping E to go back a cell has no logic ; these commits let the user choose to map B instead with the `g:csv_bind_B` variable (boolean) defined anywhere in his vim configuration. If it is not set, falls back to mapping E to previous column.

Modified files :
* `autoload/csv.vim` (main changes)
* `doc/ft-csv.txt` (for the builtin help)
* `README.md` (for the online help and to inform people there's this option)

I hope you'll merge my changes ;)