### PR TITLE
Use local vartabstop option in csv#CalculateColumnWidth

### DIFF
--- a/autoload/csv.vim
+++ b/autoload/csv.vim
@@ -776,8 +776,7 @@ fu! csv#CalculateColumnWidth(row, silent) "{{{3
     " row for the row for which to calculate the width
     let b:col_width=[]
     if has( 'vartabs' ) && b:delimiter == "\t"
-        let vts_save=&vts
-        set vts=
+        setlocal vts=
     endif
     try
         if exists("b:csv_headerline")
@@ -797,9 +796,6 @@ fu! csv#CalculateColumnWidth(row, silent) "{{{3
     " delete buffer content in variable b:csv_list,
     " this was only necessary for calculating the max width
     unlet! b:csv_list s:columnize_count s:decimal_column
-    if has( 'vartabs' ) && b:delimiter == "\t"
-        let &vts=vts_save
-    endif
 endfu
 fu! csv#Columnize(field) "{{{3
     " Internal function, not called from external,


### PR DESCRIPTION
The current logic in csv#CalculateColumnWidth with regard to the vartabstop option eventually changes the global option value and thus lets "bleed" this option to other buffers.
The change is to only use the local option.