### PR TITLE
Use &buftype=nofile

### DIFF
--- a/autoload/csv.vim
+++ b/autoload/csv.vim
@@ -1020,7 +1020,7 @@ fu! csv#SplitHeaderLine(lines, bang, hor) "{{{3
         " disable airline
         let w:airline_disabled = 1
         let win = winnr()
-        setl scrollbind buftype=nowrite bufhidden=wipe noswapfile nobuflisted
+        setl scrollbind buftype=nofile bufhidden=wipe noswapfile nobuflisted
         noa wincmd p
         let b:csv_SplitWindow = win
         aug CSV_Preview


### PR DESCRIPTION
This is technically more correct since this isn't tied to a file, but a derived buffer.

doc/options.txt:
>'buftype' 'bt'		string (default: "")
> local to buffer
> The value of this option specifies the type of a buffer:
> * \<empty\> - normal buffer
> * `nofile` - buffer which is not related to a file and will not be written
> * `nowrite` - buffer which will not be written
