### PR TITLE
Fix typo in README and help file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1324,7 +1324,7 @@ more memory than [`'maxmempattern'`](http://vimhelp.appspot.com/options.txt.html
 ## Concealing
 
 The CSV plugin comes with a function to syntax highlight csv files. Basically
-allt it does is highlight the columns and the header line.
+all it does is highlight the columns and the header line.
 
 By default, the delimiter will not be displayed, if Vim supports [`conceal`](http://vimhelp.appspot.com/syntax.txt.html#conceal) of
 syntax items and instead draws a vertical line. If you don't want that, simply

--- a/doc/ft-csv.txt
+++ b/doc/ft-csv.txt
@@ -1244,7 +1244,7 @@ more memory than 'maxmempattern'. In this case, either increase the
 4.5 Concealing					*csv-syntax*	*csv-conceal*
 --------------
 The CSV plugin comes with a function to syntax highlight csv files. Basically
-allt it does is highlight the columns and the header line.
+all it does is highlight the columns and the header line.
 
 By default, the delimiter will not be displayed, if Vim supports |conceal| of
 syntax items and instead draws a vertical line. If you don't want that, simply


### PR DESCRIPTION
Small pull request. I just happened to notice this and it was easy enough to fix. I haven't gone through and looked for other typos. Consider enabling spellcheck in your editor if it isn't enabled already.

Thanks! 🙂 