### PR TITLE
#218: restore file's vartabstop after having temporarily used it on a given line

### DIFF
--- a/autoload/csv.vim
+++ b/autoload/csv.vim
@@ -775,7 +775,11 @@ fu! csv#CalculateColumnWidth(row, silent) "{{{3
     " does not work with fixed width columns
     " row for the row for which to calculate the width
     let b:col_width=[]
+    let vts_save=""
     if has( 'vartabs' ) && b:delimiter == "\t"
+        if &l:vts
+            let vts_save=&vts
+        endif
         setlocal vts=
     endif
     try
@@ -796,6 +800,9 @@ fu! csv#CalculateColumnWidth(row, silent) "{{{3
     " delete buffer content in variable b:csv_list,
     " this was only necessary for calculating the max width
     unlet! b:csv_list s:columnize_count s:decimal_column
+    if vts_save
+        let &l:vts=vts_save
+    endif
 endfu
 fu! csv#Columnize(field) "{{{3
     " Internal function, not called from external,


### PR DESCRIPTION
Partial revert of #203 (which accidentally removed that saving while correcting vts's scope).