### PR TITLE
Fix: Improper whitespace trimming of column values

### DIFF
--- a/autoload/csv.vim
+++ b/autoload/csv.vim
@@ -2897,10 +2897,8 @@ fu! csv#GetCells(list) "{{{3
     let column=a:list
     " Delete delimiter
     call map(column, 'substitute(v:val, b:delimiter . "$", "", "g")')
-    " Revmoe trailing whitespace
-    call map(column, 'substitute(v:val, ''^\s\+$'', "", "g")')
-    " Remove leading whitespace
-    call map(column, 'substitute(v:val, ''^\s\+'', "", "g")')
+    " Remove leading and trailing whitespace
+    call map(column, 'trim(v:val)')
     return column
 endfu
 fu! CSV_CloseBuffer(buffer) "{{{3


### PR DESCRIPTION
Additionally, this fixes a bug in the first substitute call, where the regex was looking for a string consisting of entirely whitespace. This could have been fixed by changing it to

    call map(column, 'substitute(v:val, ''\s\+$'', "", "g")')

but the trim() function handles both cases without needing any regex.