### PR TITLE
Parsing Error Fixes

### DIFF
--- a/autoload/csv.vim
+++ b/autoload/csv.vim
@@ -3004,7 +3004,7 @@ fu! csv#EvalColumn(nr, func, first, last, ...) range "{{{3
         try
             let s = []
             " parse the optional number format
-            let str = matchstr(format, '/\zs[^/]*\ze/', 0, start)
+            let str = matchstr(format, '/\zs[^/]*\ze/')
             let s = matchlist(str, '\(.\)\?:\(.\)\?')[1:2]
             if empty(s)
                 " Number format wrong
@@ -3071,7 +3071,7 @@ fu! csv#SumCSVRow(line, nr) "{{{3
         try
             let s = []
             " parse the optional number format
-            let str = matchstr(format, '/\zs[^/]*\ze/', 0, start)
+            let str = matchstr(format, '/\zs[^/]*\ze/')
             let s = matchlist(str, '\(.\)\?:\(.\)\?')[1:2]
             if empty(s)
                 " Number format wrong

--- a/autoload/csv.vim
+++ b/autoload/csv.vim
@@ -1491,7 +1491,7 @@ fu! csv#AddColumn(start, stop, ...) range "{{{3
 endfu
 fu! csv#ExtractValue(item) "{{{3
     let formatThousands = '\d\+\zs\V' . s:nr_format[0] . '\m\ze\d'
-    let formatDecimal   = '\d\+\zs\V' . s:nr_format[1] . '\m\ze\d'
+    let formatDecimal   = '\(^-\?\|\d\+\)\zs\V' . s:nr_format[1] . '\m\ze\d'
     try
         let nr = substitute(a:item, formatThousands, '', 'g')
         if s:nr_format[1] != '.'


### PR DESCRIPTION
I found a couple of bugs related to the optional `/format/` argument.

* `:SumCol` was reporting wrong sums when values between -1 and 1 had no leading zero. Altering the regex fixed this.
* When selecting a range of rows, the parsing of `/format/` was failing because the variable `start` was being used incorrectly. Removing the unneeded parameters from `matchstr` fixed this.
* `:SumRow` had a similar error. In this case `start` was an undefined variable. Removing the unneeded parameters from `matchstr` fixed this.
